### PR TITLE
Add guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Every month, a Github action automatically updates the README using the data and
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [ABySS](https://github.com/bcgsc/abyss) | 10.1101/gr.214346.116 | 2023-4 |
+| [ABySS](https://github.com/bcgsc/abyss) | 10.1101/gr.214346.116 | 2023-5 |
 | [ALLPATHS](https://software.broadinstitute.org/allpaths-lg/blog/?page_id=12) | 10.1101/gr.7337908 | 2008 |
 | [BASE](https://github.com/dhlbh/BASE) | 10.1186/s12864-016-2829-5 | 2016-1 |
 | [CABOG](http://wgs-assembler.sourceforge.net) | 10.1093/bioinformatics/btn548 | 2008 |
@@ -87,10 +87,10 @@ Every month, a Github action automatically updates the README using the data and
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-4 |
+| [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-5 |
 | [FALCON](https://github.com/PacificBiosciences/FALCON) | 10.1038/nmeth.4035 | 2018-4 |
-| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-4 |
-| [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-2 |
+| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-5 |
+| [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-5 |
 | [HINGE](https://github.com/HingeAssembler/HINGE) | 10.1101/gr.216465.116 | 2019-1 |
 | [MECAT](https://github.com/xiaochuanle/MECAT) | 10.1038/nmeth.4432 | 2019-2 |
 | [MECAT2](https://github.com/xiaochuanle/MECAT2) | 10.1038/nmeth.4432 | 2020-4 |
@@ -98,7 +98,7 @@ Every month, a Github action automatically updates the README using the data and
 | [NECAT](https://github.com/xiaochuanle/NECAT) | 10.1038/s41467-020-20236-7 | 2021-3 |
 | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
 | [Ra](https://github.com/lbcb-sci/ra) | 10.1109/ISPA.2019.8868909 | 2018-12 |
-| [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2022-11 |
+| [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2023-5 |
 | [SMARTdenovo](https://github.com/ruanjue/smartdenovo) | 10.20944/preprints202009.0207.v1 | 2021-2 |
 | [wtdbg](https://github.com/ruanjue/wtdbg) |  | 2017-3 |
 | [wtdbg2](https://github.com/ruanjue/wtdbg2) | 10.1038/s41592-019-0669-3 | 2020-12 |
@@ -107,17 +107,17 @@ Every month, a Github action automatically updates the README using the data and
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-4 |
-| [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-4 |
-| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-4 |
+| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-5 |
+| [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-5 |
+| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-5 |
 | [IPA](https://github.com/PacificBiosciences/pbipa) |  | 2022-3 |
 | [LJA](https://github.com/AntonBankevich/LJA) | 10.1101/2020.12.10.420448 | 2022-1 |
 | [mdBG](https://github.com/ekimb/rust-mdbg/) | 10.1016/j.cels.2021.08.009 | 2023-1 |
-| [MBG](https://github.com/maickrau/MBG) | 10.1093/bioinformatics/btab004 | 2023-3 |
+| [MBG](https://github.com/maickrau/MBG) | 10.1093/bioinformatics/btab004 | 2023-5 |
 | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
 | [Peregrine](https://github.com/cschin/Peregrine) |  | 2022-2 |
-| [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2022-11 |
-| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-4 |
+| [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2023-5 |
+| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-5 |
 | [wtdbg2](https://github.com/ruanjue/wtdbg2) | 10.1038/s41592-019-0669-3 | 2020-12 |
 ## Assembly pre and post-processing
 
@@ -125,7 +125,7 @@ Every month, a Github action automatically updates the README using the data and
  
 | Reads | Tool  | Publication | Last update |
 |:------|:------|:------------| ----------- |
-| __Long reads__ | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-4 |
+| __Long reads__ | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-5 |
 |  | [CONSENT](https://github.com/morispi/CONSENT) | 10.1038/s41598-020-80757-5 | 2021-9 |
 |  | [Daccord](https://github.com/gt1/daccord) | 10.1101/106252 | 2018-9 |
 |  | [FLAS](https://github.com/baoe/FLAS) | 10.1093/bioinformatics/btz206 | 2019-2 |
@@ -150,7 +150,7 @@ Every month, a Github action automatically updates the README using the data and
 |:------|:------|:------------| ----------- |
 | __Long reads__ | [Arrow]() |  | 2014 |
 |  | [CONSENT](https://github.com/morispi/CONSENT) | 10.1038/s41598-020-80757-5 | 2021-9 |
-|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-2 |
+|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-5 |
 |  | [Quiver]() |  | 2014 |
 | __Long reads + short reads__ | [ Hapo-G](https://github.com/institut-de-genomique/HAPO-G) | 10.1093/nargab/lqab034 | 2023-1 |
 |  | [HyPo](https://github.com/kensung-lab/hypo) | 10.1101/2019.12.19.882506 | 2020-2 |
@@ -197,7 +197,7 @@ Every month, a Github action automatically updates the README using the data and
 | __Long reads__ | [DENTIST](https://github.com/a-ludi/dentist) | 10.1093/gigascience/giab100 | 2022-10 |
 |  | [FinisherSC](https://github.com/kakitone/finishingTool) | 10.1093/bioinformatics/btv280 | 2016-11 |
 |  | [gapless]() | 10.1101/2022.03.08.483466 |  |
-|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-2 |
+|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-5 |
 |  | [LINKS](https://github.com/bcgsc/LINKS) | 10.1186/s13742-015-0076-3 | 2023-2 |
 |  | [LRScaf](https://github.com/shingocat/lrscaf) | 10.1186/s12864-019-6337-2 | 2021-11 |
 |  | [npScarf](https://github.com/mdcao/npScarf) | 10.1038/ncomms14515 | 2019-10 |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 
 # Genome assembly tools
-List of genome assembly tools
 
-The category "Last update" takes into account commits and responses from the developers to issues.
+List of genome assembly tools based on the one presented in the review: "A deep dive into genome assemblies of non-vertebrate animals." Guiglielmoni N, Rivera-Vicéns R, Koszul R, Flot J-F. Peer Community Journal, 2022. [doi:10.24072/pcjournal.128](https://peercommunityjournal.org/articles/10.24072/pcjournal.128/)
+
+## Contributing
+
+Adding a software can be done by adding a line in the corresponding CSV file:
+* [data/assemblers.csv](data/assemblers.csv) for genome assemblers.
+* [data/processors.csv](data/processors.csv) for assembly pre- or post-processing tools.
+
+Modifications to this readme should be done in the template file of the corresponding section (see [templates](templates).
+Every month, a Github action automatically updates the README using the data and templates, fetching the latest commit date for each software.
 
 ## Table of contents
 * [Genome assemblers](#Genome-assemblers)
@@ -81,7 +89,7 @@ The category "Last update" takes into account commits and responses from the dev
 |:----------|:------------|:------------|
 | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-1 |
 | [FALCON](https://github.com/PacificBiosciences/FALCON) | 10.1038/nmeth.4035 | 2018-4 |
-| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2022-12 |
+| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-2 |
 | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-1 |
 | [HINGE](https://github.com/HingeAssembler/HINGE) | 10.1101/gr.216465.116 | 2019-1 |
 | [MECAT](https://github.com/xiaochuanle/MECAT) | 10.1038/nmeth.4432 | 2019-2 |
@@ -99,17 +107,17 @@ The category "Last update" takes into account commits and responses from the dev
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2022-12 |
+| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-2 |
 | [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-1 |
-| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-1 |
+| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-2 |
 | [IPA](https://github.com/PacificBiosciences/pbipa) |  | 2022-3 |
 | [LJA](https://github.com/AntonBankevich/LJA) | 10.1101/2020.12.10.420448 | 2022-1 |
 | [mdBG](https://github.com/ekimb/rust-mdbg/) | 10.1016/j.cels.2021.08.009 | 2023-1 |
-| [MBG](https://github.com/maickrau/MBG) | 10.1093/bioinformatics/btab004 | 2023-1 |
+| [MBG](https://github.com/maickrau/MBG) | 10.1093/bioinformatics/btab004 | 2023-2 |
 | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2022-7 |
 | [Peregrine](https://github.com/cschin/Peregrine) |  | 2022-2 |
 | [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2022-11 |
-| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-1 |
+| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-2 |
 | [wtdbg2](https://github.com/ruanjue/wtdbg2) | 10.1038/s41592-019-0669-3 | 2020-12 |
 ## Assembly pre and post-processing
 
@@ -147,7 +155,7 @@ The category "Last update" takes into account commits and responses from the dev
 | __Long reads + short reads__ | [ Hapo-G](https://github.com/institut-de-genomique/HAPO-G) | 10.1093/nargab/lqab034 | 2023-1 |
 |  | [HyPo](https://github.com/kensung-lab/hypo) | 10.1101/2019.12.19.882506 | 2020-2 |
 |  | [Racon](https://github.com/isovic/racon) | 10.1101/gr.214270.116 | 2020-8 |
-| __Short reads__ | [ntEdit](https://github.com/bcgsc/ntEdit) | 10.1093/bioinformatics/btz400 | 2023-1 |
+| __Short reads__ | [ntEdit](https://github.com/bcgsc/ntEdit) | 10.1093/bioinformatics/btz400 | 2023-2 |
 |  | [Pilon](https://github.com/broadinstitute/pilon) | 10.1371/journal.pone.0112963 | 2021-1 |
 |  | [POLCA](https://github.com/alekseyzimin/masurca) | 10.1371/journal.pcbi.1007981 | 2023-1 |
 |  | [Apollo](https://github.com/CMU-SAFARI/Apollo) | 10.1093/bioinformatics/btaa179 | 2020-5 |
@@ -171,6 +179,7 @@ The category "Last update" takes into account commits and responses from the dev
 |  | [EndHiC](https://github.com/fanagislab/EndHiC) | 10.48550/arXiv.2111.15411 | 2022-10 |
 |  | [GRAAL](https://github.com/koszullab/GRAAL) | 10.1038/ncomms6695 | 2020-1 |
 |  | [HiCAssembler](https://github.com/maxplanck-ie/HiCAssembler) | 10.1101/gad.328971.119 | 2019-11 |
+|  | [msscaf](https://github.com/mzytnicki/msscaf) |  | 2022-10 |
 |  | [instaGRAAL](https://github.com/koszullab/instaGRAAL) | 10.1186/s13059-020-02041-z | 2023-1 |
 |  | [Lachesis](https://github.com/shendurelab/LACHESIS) | 10.1038/nbt.2727 | 2017-12 |
 |  | [pin_hic](https://github.com/dfguan/pin_hic) | 10.1186/s12859-021-04453-5 | 2021-12 |
@@ -183,6 +192,8 @@ The category "Last update" takes into account commits and responses from the dev
 |  | [ARKS](https://github.com/bcgsc/arks) | 10.1186/s12859-018-2243-x | 2019-12 |
 |  | [fragScaff](https://github.com/adeylab/fragScaff) | 10.1101/gr.178319.114 | 2018-11 |
 |  | [scaff10X](https://github.com/wtsi-hpag/Scaff10X) |  | 2022-1 |
+|  | [SpLitteR](https://github.com/ablab/spades/releases/tag/splitter-paper) |  | 2022-12 |
+|  | [msscaf](https://github.com/mzytnicki/msscaf) |  | 2022-10 |
 | __Long reads__ | [DENTIST](https://github.com/a-ludi/dentist) | 10.1093/gigascience/giab100 | 2022-10 |
 |  | [FinisherSC](https://github.com/kakitone/finishingTool) | 10.1093/bioinformatics/btv280 | 2016-11 |
 |  | [gapless]() | 10.1101/2022.03.08.483466 |  |
@@ -193,6 +204,7 @@ The category "Last update" takes into account commits and responses from the dev
 |  | [PBJelly](https://sourceforge.net/projects/pb-jelly/) | 10.1371/journal.pone.0047768 | 2017 |
 |  | [RAILS](https://github.com/bcgsc/RAILS) | 10.21105/joss.00116 | 2022-12 |
 |  | [SLR](https://github.com/luojunwei/SLR) | 10.1186/s12859-019-3114-9 | 2020-8 |
+|  | [msscaf](https://github.com/mzytnicki/msscaf) |  | 2022-10 |
 |  | [SMIS](https://github.com/wtsi-hpag/smis) |  | 2018-2 |
 |  | [SMSC](https://github.com/UTbioinf/SMSC) | 10.1186/s12864-017-4271-8 | 2019-9 |
 |  | [SSPACE-LongRead]() | 10.1186/1471-2105-15-211 | 2014 |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Every month, a Github action automatically updates the README using the data and
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-6 |
+| [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-7 |
 | [FALCON](https://github.com/PacificBiosciences/FALCON) | 10.1038/nmeth.4035 | 2018-4 |
 | [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-5 |
 | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-6 |
@@ -96,7 +96,7 @@ Every month, a Github action automatically updates the README using the data and
 | [MECAT2](https://github.com/xiaochuanle/MECAT2) | 10.1038/nmeth.4432 | 2020-4 |
 | [miniasm](https://github.com/lh3/miniasm) | 10.1038/nmeth.4432 | 2019-10 |
 | [NECAT](https://github.com/xiaochuanle/NECAT) | 10.1038/s41467-020-20236-7 | 2021-3 |
-| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
+| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-7 |
 | [Ra](https://github.com/lbcb-sci/ra) | 10.1109/ISPA.2019.8868909 | 2018-12 |
 | [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2023-6 |
 | [SMARTdenovo](https://github.com/ruanjue/smartdenovo) | 10.20944/preprints202009.0207.v1 | 2021-2 |
@@ -108,16 +108,16 @@ Every month, a Github action automatically updates the README using the data and
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
 | [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-5 |
-| [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-6 |
-| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-5 |
+| [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-7 |
+| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-7 |
 | [IPA](https://github.com/PacificBiosciences/pbipa) |  | 2022-3 |
 | [LJA](https://github.com/AntonBankevich/LJA) | 10.1101/2020.12.10.420448 | 2022-1 |
 | [mdBG](https://github.com/ekimb/rust-mdbg/) | 10.1016/j.cels.2021.08.009 | 2023-1 |
 | [MBG](https://github.com/maickrau/MBG) | 10.1093/bioinformatics/btab004 | 2023-5 |
-| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
+| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-7 |
 | [Peregrine](https://github.com/cschin/Peregrine) |  | 2022-2 |
 | [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2023-6 |
-| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-6 |
+| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-7 |
 | [wtdbg2](https://github.com/ruanjue/wtdbg2) | 10.1038/s41592-019-0669-3 | 2020-12 |
 ## Assembly pre and post-processing
 
@@ -125,7 +125,7 @@ Every month, a Github action automatically updates the README using the data and
  
 | Reads | Tool  | Publication | Last update |
 |:------|:------|:------------| ----------- |
-| __Long reads__ | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-6 |
+| __Long reads__ | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-7 |
 |  | [CONSENT](https://github.com/morispi/CONSENT) | 10.1038/s41598-020-80757-5 | 2021-9 |
 |  | [Daccord](https://github.com/gt1/daccord) | 10.1101/106252 | 2018-9 |
 |  | [FLAS](https://github.com/baoe/FLAS) | 10.1093/bioinformatics/btz206 | 2019-2 |
@@ -133,7 +133,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [MECAT](https://github.com/xiaochuanle/MECAT) | 10.1038/nmeth.4432 | 2019-2 |
 |  | [MECAT2](https://github.com/xiaochuanle/MECAT2) | 10.1038/nmeth.4432 | 2020-4 |
 |  | [NECAT](https://github.com/xiaochuanle/NECAT) | 10.1038/s41467-020-20236-7 | 2021-3 |
-|  | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
+|  | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-7 |
 | __Short reads__ | [CoLoRMap](https://github.com/cchauve/CoLoRMap) | 10.1093/bioinformatics/btw463 | 2018-3 |
 |  | [Hercules](https://github.com/BilkentCompGen/Hercules) | 10.1093/nar/gky724 | 2018-8 |
 |  | [HG-CoLoR](https://github.com/morispi/HG-CoLoR) | 10.1093/bioinformatics/bty521 | 2021-1 |
@@ -142,7 +142,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [LoRMA](https://gite.lirmm.fr/lorma/lorma-releases/-/wikis/home) | 10.1093/bioinformatics/btw321 | 2019 |
 |  | [NaS](https://github.com/institut-de-genomique/NaS) | 10.1186/s12864-015-1519-z | 2017-3 |
 |  | [proovread](https://github.com/BioInf-Wuerzburg/proovread) | 10.1093/bioinformatics/btu392 | 2019-5 |
-|  | [Ratatosk](https://github.com/DecodeGenetics/Ratatosk) | 10.1186/s13059-020-02244-4 | 2023-6 |
+|  | [Ratatosk](https://github.com/DecodeGenetics/Ratatosk) | 10.1186/s13059-020-02244-4 | 2023-7 |
 
 ### Polishing
 
@@ -167,7 +167,7 @@ Every month, a Github action automatically updates the README using the data and
 | __Long reads__ | [HaploMerger2](https://github.com/mapleforest/HaploMerger2) | 10.1093/bioinformatics/btx220 | 2016-12 |
 |  | [purge_dups](https://github.com/dfguan/purge_dups) | 10.1093/bioinformatics/btaa025 | 2022-6 |
 |  | [Purge Haplotigs](https://bitbucket.org/mroachawri/purge_haplotigs) |  10.1186/s12859-018-2485-7 | 2023-6 |
-| __Long reads + short reads__ | [Redundans](https://github.com/lpryszcz/redundans) | 10.1093/nar/gkw294 | 2023-6 |
+| __Long reads + short reads__ | [Redundans](https://github.com/lpryszcz/redundans) | 10.1093/nar/gkw294 | 2023-7 |
 
 ### Scaffolding
 
@@ -198,7 +198,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [FinisherSC](https://github.com/kakitone/finishingTool) | 10.1093/bioinformatics/btv280 | 2016-11 |
 |  | [gapless]() | 10.1101/2022.03.08.483466 |  |
 |  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-6 |
-|  | [LINKS](https://github.com/bcgsc/LINKS) | 10.1186/s13742-015-0076-3 | 2023-2 |
+|  | [LINKS](https://github.com/bcgsc/LINKS) | 10.1186/s13742-015-0076-3 | 2023-7 |
 |  | [LRScaf](https://github.com/shingocat/lrscaf) | 10.1186/s12864-019-6337-2 | 2021-11 |
 |  | [npScarf](https://github.com/mdcao/npScarf) | 10.1038/ncomms14515 | 2019-10 |
 |  | [PBJelly](https://sourceforge.net/projects/pb-jelly/) | 10.1371/journal.pone.0047768 | 2017 |

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Every month, a Github action automatically updates the README using the data and
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-5 |
+| [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-6 |
 | [FALCON](https://github.com/PacificBiosciences/FALCON) | 10.1038/nmeth.4035 | 2018-4 |
 | [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-5 |
-| [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-5 |
+| [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-6 |
 | [HINGE](https://github.com/HingeAssembler/HINGE) | 10.1101/gr.216465.116 | 2019-1 |
 | [MECAT](https://github.com/xiaochuanle/MECAT) | 10.1038/nmeth.4432 | 2019-2 |
 | [MECAT2](https://github.com/xiaochuanle/MECAT2) | 10.1038/nmeth.4432 | 2020-4 |
@@ -98,7 +98,7 @@ Every month, a Github action automatically updates the README using the data and
 | [NECAT](https://github.com/xiaochuanle/NECAT) | 10.1038/s41467-020-20236-7 | 2021-3 |
 | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
 | [Ra](https://github.com/lbcb-sci/ra) | 10.1109/ISPA.2019.8868909 | 2018-12 |
-| [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2023-5 |
+| [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2023-6 |
 | [SMARTdenovo](https://github.com/ruanjue/smartdenovo) | 10.20944/preprints202009.0207.v1 | 2021-2 |
 | [wtdbg](https://github.com/ruanjue/wtdbg) |  | 2017-3 |
 | [wtdbg2](https://github.com/ruanjue/wtdbg2) | 10.1038/s41592-019-0669-3 | 2020-12 |
@@ -108,7 +108,7 @@ Every month, a Github action automatically updates the README using the data and
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
 | [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-5 |
-| [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-5 |
+| [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-6 |
 | [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-5 |
 | [IPA](https://github.com/PacificBiosciences/pbipa) |  | 2022-3 |
 | [LJA](https://github.com/AntonBankevich/LJA) | 10.1101/2020.12.10.420448 | 2022-1 |
@@ -116,8 +116,8 @@ Every month, a Github action automatically updates the README using the data and
 | [MBG](https://github.com/maickrau/MBG) | 10.1093/bioinformatics/btab004 | 2023-5 |
 | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
 | [Peregrine](https://github.com/cschin/Peregrine) |  | 2022-2 |
-| [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2023-5 |
-| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-5 |
+| [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2023-6 |
+| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-6 |
 | [wtdbg2](https://github.com/ruanjue/wtdbg2) | 10.1038/s41592-019-0669-3 | 2020-12 |
 ## Assembly pre and post-processing
 
@@ -125,7 +125,7 @@ Every month, a Github action automatically updates the README using the data and
  
 | Reads | Tool  | Publication | Last update |
 |:------|:------|:------------| ----------- |
-| __Long reads__ | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-5 |
+| __Long reads__ | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-6 |
 |  | [CONSENT](https://github.com/morispi/CONSENT) | 10.1038/s41598-020-80757-5 | 2021-9 |
 |  | [Daccord](https://github.com/gt1/daccord) | 10.1101/106252 | 2018-9 |
 |  | [FLAS](https://github.com/baoe/FLAS) | 10.1093/bioinformatics/btz206 | 2019-2 |
@@ -142,7 +142,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [LoRMA](https://gite.lirmm.fr/lorma/lorma-releases/-/wikis/home) | 10.1093/bioinformatics/btw321 | 2019 |
 |  | [NaS](https://github.com/institut-de-genomique/NaS) | 10.1186/s12864-015-1519-z | 2017-3 |
 |  | [proovread](https://github.com/BioInf-Wuerzburg/proovread) | 10.1093/bioinformatics/btu392 | 2019-5 |
-|  | [Ratatosk](https://github.com/DecodeGenetics/Ratatosk) | 10.1186/s13059-020-02244-4 | 2022-11 |
+|  | [Ratatosk](https://github.com/DecodeGenetics/Ratatosk) | 10.1186/s13059-020-02244-4 | 2023-6 |
 
 ### Polishing
 
@@ -150,12 +150,12 @@ Every month, a Github action automatically updates the README using the data and
 |:------|:------|:------------| ----------- |
 | __Long reads__ | [Arrow]() |  | 2014 |
 |  | [CONSENT](https://github.com/morispi/CONSENT) | 10.1038/s41598-020-80757-5 | 2021-9 |
-|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-5 |
+|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-6 |
 |  | [Quiver]() |  | 2014 |
 | __Long reads + short reads__ | [ Hapo-G](https://github.com/institut-de-genomique/HAPO-G) | 10.1093/nargab/lqab034 | 2023-1 |
 |  | [HyPo](https://github.com/kensung-lab/hypo) | 10.1101/2019.12.19.882506 | 2020-2 |
 |  | [Racon](https://github.com/isovic/racon) | 10.1101/gr.214270.116 | 2020-8 |
-| __Short reads__ | [ntEdit](https://github.com/bcgsc/ntEdit) | 10.1093/bioinformatics/btz400 | 2023-4 |
+| __Short reads__ | [ntEdit](https://github.com/bcgsc/ntEdit) | 10.1093/bioinformatics/btz400 | 2023-6 |
 |  | [Pilon](https://github.com/broadinstitute/pilon) | 10.1371/journal.pone.0112963 | 2021-1 |
 |  | [POLCA](https://github.com/alekseyzimin/masurca) | 10.1371/journal.pcbi.1007981 | 2023-3 |
 |  | [Apollo](https://github.com/CMU-SAFARI/Apollo) | 10.1093/bioinformatics/btaa179 | 2020-5 |
@@ -166,8 +166,8 @@ Every month, a Github action automatically updates the README using the data and
 |:------|:------|:------------| ----------- |
 | __Long reads__ | [HaploMerger2](https://github.com/mapleforest/HaploMerger2) | 10.1093/bioinformatics/btx220 | 2016-12 |
 |  | [purge_dups](https://github.com/dfguan/purge_dups) | 10.1093/bioinformatics/btaa025 | 2022-6 |
-|  | [Purge Haplotigs](https://bitbucket.org/mroachawri/purge_haplotigs) |  10.1186/s12859-018-2485-7 | 2023-3 |
-| __Long reads + short reads__ | [Redundans](https://github.com/lpryszcz/redundans) | 10.1093/nar/gkw294 | 2022-12 |
+|  | [Purge Haplotigs](https://bitbucket.org/mroachawri/purge_haplotigs) |  10.1186/s12859-018-2485-7 | 2023-6 |
+| __Long reads + short reads__ | [Redundans](https://github.com/lpryszcz/redundans) | 10.1093/nar/gkw294 | 2023-6 |
 
 ### Scaffolding
 
@@ -185,7 +185,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [pin_hic](https://github.com/dfguan/pin_hic) | 10.1186/s12859-021-04453-5 | 2021-12 |
 |  | [SALSA2](https://github.com/marbl/SALSA) | 10.1371/journal.pcbi.1007273 | 2022-4 |
 |  | [scaffHiC](https://github.com/wtsi-hpag/scaffHiC) |  | 2022-12 |
-|  | [YaHS](https://github.com/c-zhou/yahs) |  | 2023-4 |
+|  | [YaHS](https://github.com/c-zhou/yahs) |  | 2023-6 |
 | __Linked reads__ | [ ARBitR](https://github.com/markhilt/ARBitR) | 10.1093/bioinformatics/btaa975 | 2020-10 |
 |  | [Architect](https://github.com/kuleshov/architect) | 10.1093/bioinformatics/btw267 | 2016-10 |
 |  | [ARCS](https://github.com/bcgsc/ARCS/) | 10.1093/bioinformatics/btx675 | 2023-4 |
@@ -197,7 +197,7 @@ Every month, a Github action automatically updates the README using the data and
 | __Long reads__ | [DENTIST](https://github.com/a-ludi/dentist) | 10.1093/gigascience/giab100 | 2022-10 |
 |  | [FinisherSC](https://github.com/kakitone/finishingTool) | 10.1093/bioinformatics/btv280 | 2016-11 |
 |  | [gapless]() | 10.1101/2022.03.08.483466 |  |
-|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-5 |
+|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-6 |
 |  | [LINKS](https://github.com/bcgsc/LINKS) | 10.1186/s13742-015-0076-3 | 2023-2 |
 |  | [LRScaf](https://github.com/shingocat/lrscaf) | 10.1186/s12864-019-6337-2 | 2021-11 |
 |  | [npScarf](https://github.com/mdcao/npScarf) | 10.1038/ncomms14515 | 2019-10 |

--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ Every month, a Github action automatically updates the README using the data and
 |:----------|:------------|:------------|
 | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-1 |
 | [FALCON](https://github.com/PacificBiosciences/FALCON) | 10.1038/nmeth.4035 | 2018-4 |
-| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-2 |
-| [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-1 |
+| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-3 |
+| [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-3 |
 | [HINGE](https://github.com/HingeAssembler/HINGE) | 10.1101/gr.216465.116 | 2019-1 |
 | [MECAT](https://github.com/xiaochuanle/MECAT) | 10.1038/nmeth.4432 | 2019-2 |
 | [MECAT2](https://github.com/xiaochuanle/MECAT2) | 10.1038/nmeth.4432 | 2020-4 |
 | [miniasm](https://github.com/lh3/miniasm) | 10.1038/nmeth.4432 | 2019-10 |
 | [NECAT](https://github.com/xiaochuanle/NECAT) | 10.1038/s41467-020-20236-7 | 2021-3 |
-| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2022-7 |
+| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-3 |
 | [Ra](https://github.com/lbcb-sci/ra) | 10.1109/ISPA.2019.8868909 | 2018-12 |
 | [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2022-11 |
 | [SMARTdenovo](https://github.com/ruanjue/smartdenovo) | 10.20944/preprints202009.0207.v1 | 2021-2 |
@@ -107,17 +107,17 @@ Every month, a Github action automatically updates the README using the data and
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-2 |
+| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-3 |
 | [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-1 |
-| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-2 |
+| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-3 |
 | [IPA](https://github.com/PacificBiosciences/pbipa) |  | 2022-3 |
 | [LJA](https://github.com/AntonBankevich/LJA) | 10.1101/2020.12.10.420448 | 2022-1 |
 | [mdBG](https://github.com/ekimb/rust-mdbg/) | 10.1016/j.cels.2021.08.009 | 2023-1 |
-| [MBG](https://github.com/maickrau/MBG) | 10.1093/bioinformatics/btab004 | 2023-2 |
-| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2022-7 |
+| [MBG](https://github.com/maickrau/MBG) | 10.1093/bioinformatics/btab004 | 2023-3 |
+| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-3 |
 | [Peregrine](https://github.com/cschin/Peregrine) |  | 2022-2 |
 | [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2022-11 |
-| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-2 |
+| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-3 |
 | [wtdbg2](https://github.com/ruanjue/wtdbg2) | 10.1038/s41592-019-0669-3 | 2020-12 |
 ## Assembly pre and post-processing
 
@@ -133,7 +133,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [MECAT](https://github.com/xiaochuanle/MECAT) | 10.1038/nmeth.4432 | 2019-2 |
 |  | [MECAT2](https://github.com/xiaochuanle/MECAT2) | 10.1038/nmeth.4432 | 2020-4 |
 |  | [NECAT](https://github.com/xiaochuanle/NECAT) | 10.1038/s41467-020-20236-7 | 2021-3 |
-|  | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2022-7 |
+|  | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-3 |
 | __Short reads__ | [CoLoRMap](https://github.com/cchauve/CoLoRMap) | 10.1093/bioinformatics/btw463 | 2018-3 |
 |  | [Hercules](https://github.com/BilkentCompGen/Hercules) | 10.1093/nar/gky724 | 2018-8 |
 |  | [HG-CoLoR](https://github.com/morispi/HG-CoLoR) | 10.1093/bioinformatics/bty521 | 2021-1 |
@@ -150,14 +150,14 @@ Every month, a Github action automatically updates the README using the data and
 |:------|:------|:------------| ----------- |
 | __Long reads__ | [Arrow]() |  | 2014 |
 |  | [CONSENT](https://github.com/morispi/CONSENT) | 10.1038/s41598-020-80757-5 | 2021-9 |
-|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-1 |
+|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-3 |
 |  | [Quiver]() |  | 2014 |
 | __Long reads + short reads__ | [ Hapo-G](https://github.com/institut-de-genomique/HAPO-G) | 10.1093/nargab/lqab034 | 2023-1 |
 |  | [HyPo](https://github.com/kensung-lab/hypo) | 10.1101/2019.12.19.882506 | 2020-2 |
 |  | [Racon](https://github.com/isovic/racon) | 10.1101/gr.214270.116 | 2020-8 |
-| __Short reads__ | [ntEdit](https://github.com/bcgsc/ntEdit) | 10.1093/bioinformatics/btz400 | 2023-2 |
+| __Short reads__ | [ntEdit](https://github.com/bcgsc/ntEdit) | 10.1093/bioinformatics/btz400 | 2023-3 |
 |  | [Pilon](https://github.com/broadinstitute/pilon) | 10.1371/journal.pone.0112963 | 2021-1 |
-|  | [POLCA](https://github.com/alekseyzimin/masurca) | 10.1371/journal.pcbi.1007981 | 2023-1 |
+|  | [POLCA](https://github.com/alekseyzimin/masurca) | 10.1371/journal.pcbi.1007981 | 2023-3 |
 |  | [Apollo](https://github.com/CMU-SAFARI/Apollo) | 10.1093/bioinformatics/btaa179 | 2020-5 |
 
 ### Haplotig purging
@@ -166,7 +166,7 @@ Every month, a Github action automatically updates the README using the data and
 |:------|:------|:------------| ----------- |
 | __Long reads__ | [HaploMerger2](https://github.com/mapleforest/HaploMerger2) | 10.1093/bioinformatics/btx220 | 2016-12 |
 |  | [purge_dups](https://github.com/dfguan/purge_dups) | 10.1093/bioinformatics/btaa025 | 2022-6 |
-|  | [Purge Haplotigs](https://bitbucket.org/mroachawri/purge_haplotigs) |  10.1186/s12859-018-2485-7 | 2021-11 |
+|  | [Purge Haplotigs](https://bitbucket.org/mroachawri/purge_haplotigs) |  10.1186/s12859-018-2485-7 | 2023-3 |
 | __Long reads + short reads__ | [Redundans](https://github.com/lpryszcz/redundans) | 10.1093/nar/gkw294 | 2022-12 |
 
 ### Scaffolding
@@ -197,7 +197,7 @@ Every month, a Github action automatically updates the README using the data and
 | __Long reads__ | [DENTIST](https://github.com/a-ludi/dentist) | 10.1093/gigascience/giab100 | 2022-10 |
 |  | [FinisherSC](https://github.com/kakitone/finishingTool) | 10.1093/bioinformatics/btv280 | 2016-11 |
 |  | [gapless]() | 10.1101/2022.03.08.483466 |  |
-|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-1 |
+|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-3 |
 |  | [LINKS](https://github.com/bcgsc/LINKS) | 10.1186/s13742-015-0076-3 | 2023-2 |
 |  | [LRScaf](https://github.com/shingocat/lrscaf) | 10.1186/s12864-019-6337-2 | 2021-11 |
 |  | [npScarf](https://github.com/mdcao/npScarf) | 10.1038/ncomms14515 | 2019-10 |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Adding a software can be done by adding a line in the corresponding CSV file:
 * [data/assemblers.csv](data/assemblers.csv) for genome assemblers.
 * [data/processors.csv](data/processors.csv) for assembly pre- or post-processing tools.
 
-Modifications to this readme should be done in the template file of the corresponding section (see [templates](templates).
+Modifications to this readme should be done in the template file of the corresponding section (see [templates](templates)).
 Every month, a Github action automatically updates the README using the data and templates, fetching the latest commit date for each software.
 
 ## Table of contents
@@ -188,7 +188,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [YaHS](https://github.com/c-zhou/yahs) |  | 2022-12 |
 | __Linked reads__ | [ ARBitR](https://github.com/markhilt/ARBitR) | 10.1093/bioinformatics/btaa975 | 2020-10 |
 |  | [Architect](https://github.com/kuleshov/architect) | 10.1093/bioinformatics/btw267 | 2016-10 |
-|  | [ARCS](https://github.com/bcgsc/ARCS/) | 10.1093/bioinformatics/btx675 | 2023-1 |
+|  | [ARCS](https://github.com/bcgsc/ARCS/) | 10.1093/bioinformatics/btx675 | 2023-2 |
 |  | [ARKS](https://github.com/bcgsc/arks) | 10.1186/s12859-018-2243-x | 2019-12 |
 |  | [fragScaff](https://github.com/adeylab/fragScaff) | 10.1101/gr.178319.114 | 2018-11 |
 |  | [scaff10X](https://github.com/wtsi-hpag/Scaff10X) |  | 2022-1 |
@@ -198,11 +198,11 @@ Every month, a Github action automatically updates the README using the data and
 |  | [FinisherSC](https://github.com/kakitone/finishingTool) | 10.1093/bioinformatics/btv280 | 2016-11 |
 |  | [gapless]() | 10.1101/2022.03.08.483466 |  |
 |  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-1 |
-|  | [LINKS](https://github.com/bcgsc/LINKS) | 10.1186/s13742-015-0076-3 | 2022-12 |
+|  | [LINKS](https://github.com/bcgsc/LINKS) | 10.1186/s13742-015-0076-3 | 2023-2 |
 |  | [LRScaf](https://github.com/shingocat/lrscaf) | 10.1186/s12864-019-6337-2 | 2021-11 |
 |  | [npScarf](https://github.com/mdcao/npScarf) | 10.1038/ncomms14515 | 2019-10 |
 |  | [PBJelly](https://sourceforge.net/projects/pb-jelly/) | 10.1371/journal.pone.0047768 | 2017 |
-|  | [RAILS](https://github.com/bcgsc/RAILS) | 10.21105/joss.00116 | 2022-12 |
+|  | [RAILS](https://github.com/bcgsc/RAILS) | 10.21105/joss.00116 | 2023-2 |
 |  | [SLR](https://github.com/luojunwei/SLR) | 10.1186/s12859-019-3114-9 | 2020-8 |
 |  | [msscaf](https://github.com/mzytnicki/msscaf) |  | 2022-10 |
 |  | [SMIS](https://github.com/wtsi-hpag/smis) |  | 2018-2 |
@@ -233,7 +233,7 @@ Every month, a Github action automatically updates the README using the data and
 
 | Reads | Tool  | Publication | Last update |
 |:------|:------|:------------| ----------- |
-| __Long reads__ | [Cobbler](https://github.com/bcgsc/RAILS) | 10.21105/joss.00116 | 2022-12 |
+| __Long reads__ | [Cobbler](https://github.com/bcgsc/RAILS) | 10.21105/joss.00116 | 2023-2 |
 |  | [DENTIST](https://github.com/a-ludi/dentist) | 10.1093/gigascience/giab100 | 2022-10 |
 |  | [FGAP](https://github.com/pirovc/fgap) | 10.1186/1756-0500-7-371 | 2017-12 |
 |  | [FinisherSC](https://github.com/kakitone/finishingTool) | 10.1093/bioinformatics/btv280 | 2016-11 |
@@ -243,7 +243,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [PBJelly](https://sourceforge.net/projects/pb-jelly/) | 10.1371/journal.pone.0047768 | 2017 |
 |  | [PGcloser]() | 10.1177/1176934320913859 | 2020 |
 |  | [TGS-GapCloser](https://github.com/BGI-Qingdao/TGS-GapCloser) | 10.1093/gigascience/giaa094 | 2022-12 |
-|  | [YAGCloser](https://github.com/merlyescalona/yagcloser) |  | 2022-3 |
+|  | [YAGCloser](https://github.com/merlyescalona/yagcloser) |  | 2023-2 |
 | __Short reads__ | [GapFiller]() | 10.1186/gb-2012-13-6-r56 |  |
 |  | [GAPPadder]() | 10.1186/s12864-019-5703-4 |  |
 |  | [Sealer]() | 10.1186/s12859-015-0663-4 |  |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Every month, a Github action automatically updates the README using the data and
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [ABySS](https://github.com/bcgsc/abyss) | 10.1101/gr.214346.116 | 2023-1 |
+| [ABySS](https://github.com/bcgsc/abyss) | 10.1101/gr.214346.116 | 2023-4 |
 | [ALLPATHS](https://software.broadinstitute.org/allpaths-lg/blog/?page_id=12) | 10.1101/gr.7337908 | 2008 |
 | [BASE](https://github.com/dhlbh/BASE) | 10.1186/s12864-016-2829-5 | 2016-1 |
 | [CABOG](http://wgs-assembler.sourceforge.net) | 10.1093/bioinformatics/btn548 | 2008 |
@@ -87,16 +87,16 @@ Every month, a Github action automatically updates the README using the data and
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-1 |
+| [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-4 |
 | [FALCON](https://github.com/PacificBiosciences/FALCON) | 10.1038/nmeth.4035 | 2018-4 |
-| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-3 |
-| [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-3 |
+| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-4 |
+| [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-2 |
 | [HINGE](https://github.com/HingeAssembler/HINGE) | 10.1101/gr.216465.116 | 2019-1 |
 | [MECAT](https://github.com/xiaochuanle/MECAT) | 10.1038/nmeth.4432 | 2019-2 |
 | [MECAT2](https://github.com/xiaochuanle/MECAT2) | 10.1038/nmeth.4432 | 2020-4 |
 | [miniasm](https://github.com/lh3/miniasm) | 10.1038/nmeth.4432 | 2019-10 |
 | [NECAT](https://github.com/xiaochuanle/NECAT) | 10.1038/s41467-020-20236-7 | 2021-3 |
-| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-3 |
+| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
 | [Ra](https://github.com/lbcb-sci/ra) | 10.1109/ISPA.2019.8868909 | 2018-12 |
 | [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2022-11 |
 | [SMARTdenovo](https://github.com/ruanjue/smartdenovo) | 10.20944/preprints202009.0207.v1 | 2021-2 |
@@ -107,17 +107,17 @@ Every month, a Github action automatically updates the README using the data and
 
 | Assembler | Publication | Last update |
 |:----------|:------------|:------------|
-| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-3 |
-| [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-1 |
-| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-3 |
+| [Flye](https://github.com/fenderglass/Flye) | 10.1038/s41587-019-0072-8 | 2023-4 |
+| [HiCanu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-4 |
+| [hifiasm](https://github.com/chhylp123/hifiasm) | 10.1038/s41592-020-01056-5 | 2023-4 |
 | [IPA](https://github.com/PacificBiosciences/pbipa) |  | 2022-3 |
 | [LJA](https://github.com/AntonBankevich/LJA) | 10.1101/2020.12.10.420448 | 2022-1 |
 | [mdBG](https://github.com/ekimb/rust-mdbg/) | 10.1016/j.cels.2021.08.009 | 2023-1 |
 | [MBG](https://github.com/maickrau/MBG) | 10.1093/bioinformatics/btab004 | 2023-3 |
-| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-3 |
+| [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
 | [Peregrine](https://github.com/cschin/Peregrine) |  | 2022-2 |
 | [Raven](https://github.com/lbcb-sci/raven) | 10.1038/s43588-021-00073-4 | 2022-11 |
-| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-3 |
+| [verkko](https://github.com/marbl/verkko) | 10.1101/2022.06.24.497523 | 2023-4 |
 | [wtdbg2](https://github.com/ruanjue/wtdbg2) | 10.1038/s41592-019-0669-3 | 2020-12 |
 ## Assembly pre and post-processing
 
@@ -125,7 +125,7 @@ Every month, a Github action automatically updates the README using the data and
  
 | Reads | Tool  | Publication | Last update |
 |:------|:------|:------------| ----------- |
-| __Long reads__ | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-1 |
+| __Long reads__ | [Canu](https://github.com/marbl/canu) | 10.1101/gr.215087.116 | 2023-4 |
 |  | [CONSENT](https://github.com/morispi/CONSENT) | 10.1038/s41598-020-80757-5 | 2021-9 |
 |  | [Daccord](https://github.com/gt1/daccord) | 10.1101/106252 | 2018-9 |
 |  | [FLAS](https://github.com/baoe/FLAS) | 10.1093/bioinformatics/btz206 | 2019-2 |
@@ -133,7 +133,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [MECAT](https://github.com/xiaochuanle/MECAT) | 10.1038/nmeth.4432 | 2019-2 |
 |  | [MECAT2](https://github.com/xiaochuanle/MECAT2) | 10.1038/nmeth.4432 | 2020-4 |
 |  | [NECAT](https://github.com/xiaochuanle/NECAT) | 10.1038/s41467-020-20236-7 | 2021-3 |
-|  | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-3 |
+|  | [NextDenovo](https://github.com/Nextomics/NextDenovo) |  | 2023-4 |
 | __Short reads__ | [CoLoRMap](https://github.com/cchauve/CoLoRMap) | 10.1093/bioinformatics/btw463 | 2018-3 |
 |  | [Hercules](https://github.com/BilkentCompGen/Hercules) | 10.1093/nar/gky724 | 2018-8 |
 |  | [HG-CoLoR](https://github.com/morispi/HG-CoLoR) | 10.1093/bioinformatics/bty521 | 2021-1 |
@@ -150,12 +150,12 @@ Every month, a Github action automatically updates the README using the data and
 |:------|:------|:------------| ----------- |
 | __Long reads__ | [Arrow]() |  | 2014 |
 |  | [CONSENT](https://github.com/morispi/CONSENT) | 10.1038/s41598-020-80757-5 | 2021-9 |
-|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-3 |
+|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-2 |
 |  | [Quiver]() |  | 2014 |
 | __Long reads + short reads__ | [ Hapo-G](https://github.com/institut-de-genomique/HAPO-G) | 10.1093/nargab/lqab034 | 2023-1 |
 |  | [HyPo](https://github.com/kensung-lab/hypo) | 10.1101/2019.12.19.882506 | 2020-2 |
 |  | [Racon](https://github.com/isovic/racon) | 10.1101/gr.214270.116 | 2020-8 |
-| __Short reads__ | [ntEdit](https://github.com/bcgsc/ntEdit) | 10.1093/bioinformatics/btz400 | 2023-3 |
+| __Short reads__ | [ntEdit](https://github.com/bcgsc/ntEdit) | 10.1093/bioinformatics/btz400 | 2023-4 |
 |  | [Pilon](https://github.com/broadinstitute/pilon) | 10.1371/journal.pone.0112963 | 2021-1 |
 |  | [POLCA](https://github.com/alekseyzimin/masurca) | 10.1371/journal.pcbi.1007981 | 2023-3 |
 |  | [Apollo](https://github.com/CMU-SAFARI/Apollo) | 10.1093/bioinformatics/btaa179 | 2020-5 |
@@ -185,10 +185,10 @@ Every month, a Github action automatically updates the README using the data and
 |  | [pin_hic](https://github.com/dfguan/pin_hic) | 10.1186/s12859-021-04453-5 | 2021-12 |
 |  | [SALSA2](https://github.com/marbl/SALSA) | 10.1371/journal.pcbi.1007273 | 2022-4 |
 |  | [scaffHiC](https://github.com/wtsi-hpag/scaffHiC) |  | 2022-12 |
-|  | [YaHS](https://github.com/c-zhou/yahs) |  | 2022-12 |
+|  | [YaHS](https://github.com/c-zhou/yahs) |  | 2023-4 |
 | __Linked reads__ | [ ARBitR](https://github.com/markhilt/ARBitR) | 10.1093/bioinformatics/btaa975 | 2020-10 |
 |  | [Architect](https://github.com/kuleshov/architect) | 10.1093/bioinformatics/btw267 | 2016-10 |
-|  | [ARCS](https://github.com/bcgsc/ARCS/) | 10.1093/bioinformatics/btx675 | 2023-2 |
+|  | [ARCS](https://github.com/bcgsc/ARCS/) | 10.1093/bioinformatics/btx675 | 2023-4 |
 |  | [ARKS](https://github.com/bcgsc/arks) | 10.1186/s12859-018-2243-x | 2019-12 |
 |  | [fragScaff](https://github.com/adeylab/fragScaff) | 10.1101/gr.178319.114 | 2018-11 |
 |  | [scaff10X](https://github.com/wtsi-hpag/Scaff10X) |  | 2022-1 |
@@ -197,7 +197,7 @@ Every month, a Github action automatically updates the README using the data and
 | __Long reads__ | [DENTIST](https://github.com/a-ludi/dentist) | 10.1093/gigascience/giab100 | 2022-10 |
 |  | [FinisherSC](https://github.com/kakitone/finishingTool) | 10.1093/bioinformatics/btv280 | 2016-11 |
 |  | [gapless]() | 10.1101/2022.03.08.483466 |  |
-|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-3 |
+|  | [GoldRush](https://github.com/bcgsc/goldrush) | 10.1101/2022.10.25.513734 | 2023-2 |
 |  | [LINKS](https://github.com/bcgsc/LINKS) | 10.1186/s13742-015-0076-3 | 2023-2 |
 |  | [LRScaf](https://github.com/shingocat/lrscaf) | 10.1186/s12864-019-6337-2 | 2021-11 |
 |  | [npScarf](https://github.com/mdcao/npScarf) | 10.1038/ncomms14515 | 2019-10 |
@@ -242,7 +242,7 @@ Every month, a Github action automatically updates the README using the data and
 |  | [LR_Gapcloser](https://github.com/CAFS-bioinformatics/LR_Gapcloser) |  10.1093/gigascience/giy157 | 2018-9 |
 |  | [PBJelly](https://sourceforge.net/projects/pb-jelly/) | 10.1371/journal.pone.0047768 | 2017 |
 |  | [PGcloser]() | 10.1177/1176934320913859 | 2020 |
-|  | [TGS-GapCloser](https://github.com/BGI-Qingdao/TGS-GapCloser) | 10.1093/gigascience/giaa094 | 2022-12 |
+|  | [TGS-GapCloser](https://github.com/BGI-Qingdao/TGS-GapCloser) | 10.1093/gigascience/giaa094 | 2023-4 |
 |  | [YAGCloser](https://github.com/merlyescalona/yagcloser) |  | 2023-2 |
 | __Short reads__ | [GapFiller]() | 10.1186/gb-2012-13-6-r56 |  |
 |  | [GAPPadder]() | 10.1186/s12864-019-5703-4 |  |

--- a/data/processors.csv
+++ b/data/processors.csv
@@ -57,6 +57,7 @@ Scaffolding,Long reads,npScarf,https://github.com/mdcao/npScarf,10.1038/ncomms14
 Scaffolding,Long reads,PBJelly,https://sourceforge.net/projects/pb-jelly/,10.1371/journal.pone.0047768,2017
 Scaffolding,Long reads,RAILS,https://github.com/bcgsc/RAILS,10.21105/joss.00116,2021
 Scaffolding,Long reads,SLR,https://github.com/luojunwei/SLR,10.1186/s12859-019-3114-9,2020
+Scaffolding,Long reads,msscaf,https://github.com/mzytnicki/msscaf,,2022
 Scaffolding,Long reads,SMIS,https://github.com/wtsi-hpag/smis,,2018
 Scaffolding,Long reads,SMSC,https://github.com/UTbioinf/SMSC,10.1186/s12864-017-4271-8,2019
 Scaffolding,Long reads,SSPACE-LongRead,,10.1186/1471-2105-15-211,2014
@@ -72,11 +73,14 @@ Scaffolding,Linked reads,ARCS,https://github.com/bcgsc/ARCS/,10.1093/bioinformat
 Scaffolding,Linked reads,ARKS,https://github.com/bcgsc/arks,10.1186/s12859-018-2243-x,2019
 Scaffolding,Linked reads,fragScaff,https://github.com/adeylab/fragScaff,10.1101/gr.178319.114,2018
 Scaffolding,Linked reads,scaff10X,https://github.com/wtsi-hpag/Scaff10X,,2022
+Scaffolding,Linked reads,SpLitteR,https://github.com/ablab/spades/releases/tag/splitter-paper,,2022-12
+Scaffolding,Linked reads,msscaf,https://github.com/mzytnicki/msscaf,,2022
 Scaffolding,Hi-C,3D-DNA,https://github.com/aidenlab/3d-dna,10.1126/science.aal3327,2021
 Scaffolding,Hi-C,dnaTri,https://github.com/NoamKaplan/dna-triangulation,10.1038/nbt.2768,2016
 Scaffolding,Hi-C,EndHiC,https://github.com/fanagislab/EndHiC,10.48550/arXiv.2111.15411,2022
 Scaffolding,Hi-C,GRAAL,https://github.com/koszullab/GRAAL,10.1038/ncomms6695,2018
 Scaffolding,Hi-C,HiCAssembler,https://github.com/maxplanck-ie/HiCAssembler,10.1101/gad.328971.119,2019
+Scaffolding,Hi-C,msscaf,https://github.com/mzytnicki/msscaf,,2022
 Scaffolding,Hi-C,instaGRAAL,https://github.com/koszullab/instaGRAAL,10.1186/s13059-020-02041-z,2022
 Scaffolding,Hi-C,Lachesis,https://github.com/shendurelab/LACHESIS,10.1038/nbt.2727,2017
 Scaffolding,Hi-C,pin_hic,https://github.com/dfguan/pin_hic,10.1186/s12859-021-04453-5,2021

--- a/templates/header.md
+++ b/templates/header.md
@@ -1,8 +1,16 @@
 
 # Genome assembly tools
-List of genome assembly tools
 
-The category "Last update" takes into account commits and responses from the developers to issues.
+List of genome assembly tools based on the one presented in the review: "A deep dive into genome assemblies of non-vertebrate animals." Guiglielmoni N, Rivera-Vicéns R, Koszul R, Flot J-F. Peer Community Journal, 2022. [doi:10.24072/pcjournal.128](https://peercommunityjournal.org/articles/10.24072/pcjournal.128/)
+
+## Contributing
+
+Adding a software can be done by adding a line in the corresponding CSV file:
+* [data/assemblers.csv](data/assemblers.csv) for genome assemblers.
+* [data/processors.csv](data/processors.csv) for assembly pre- or post-processing tools.
+
+Modifications to this readme should be done in the template file of the corresponding section (see [templates](templates).
+Every month, a Github action automatically updates the README using the data and templates, fetching the latest commit date for each software.
 
 ## Table of contents
 * [Genome assemblers](#Genome-assemblers)

--- a/templates/header.md
+++ b/templates/header.md
@@ -9,7 +9,7 @@ Adding a software can be done by adding a line in the corresponding CSV file:
 * [data/assemblers.csv](data/assemblers.csv) for genome assemblers.
 * [data/processors.csv](data/processors.csv) for assembly pre- or post-processing tools.
 
-Modifications to this readme should be done in the template file of the corresponding section (see [templates](templates).
+Modifications to this readme should be done in the template file of the corresponding section (see [templates](templates)).
 Every month, a Github action automatically updates the README using the data and templates, fetching the latest commit date for each software.
 
 ## Table of contents


### PR DESCRIPTION
Hi @nadegeguiglielmoni!

I noticed the last 2 softwares you added (msscaf and Splitter) were auto removed by the github actions.
This is because the github action automatically regenerates (i.e. overwrites) the readme every month as follows:

```mermaid
flowchart TD
    data_a[data/assemblers.csv] --> list_a[assemblers table]
    temp_a[templates/assemblers.j2] --> |fill| list_a
    data_p[data/processors.csv] --> list_p[processors table]
    temp_p[templates/processors.j2] --> |fill| list_p
    list_a --> |cat| readme
    list_p --> |cat| readme
    header[templates/header.md] --> |cat|readme[README.md]

```
So the single source of truth are the csv files. The data is filled in using templates, and everything is `cat` into the README.
This means that one should edit the text in templates and the data in csv files, but not directly in the readme, because changes in the readme will be overwritten by the github action.

This PR adds guidelines describing what files to modify to contribute, and adds back the two software that were removed by GH action.

> I originally added this because I thought it'd be nice to automatically keep "last update" times up to date, and also because a CSV file is always convenient for reuse, but if you think this is overkill or inconvenient, feel free to disable the github action.